### PR TITLE
صيانة أخطاء بناء المشروع

### DIFF
--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -40,4 +40,4 @@ const connectDB = async () => {
   }
 };
 
-export default connectDB;
+module.exports = connectDB;

--- a/backend/models/Contact.js
+++ b/backend/models/Contact.js
@@ -172,4 +172,4 @@ contactSchema.statics.detectSpam = function(message, email) {
   return hasSpamKeywords || hasSuspiciousPattern;
 };
 
-export default mongoose.model('Contact', contactSchema);
+module.exports = mongoose.model('Contact', contactSchema);

--- a/backend/models/Project.js
+++ b/backend/models/Project.js
@@ -181,4 +181,4 @@ projectSchema.methods.incrementViews = function() {
   return this.save();
 };
 
-export default mongoose.model('Project', projectSchema);
+module.exports = mongoose.model('Project', projectSchema);

--- a/backend/models/TeamMember.js
+++ b/backend/models/TeamMember.js
@@ -129,4 +129,4 @@ teamMemberSchema.statics.getActiveMembers = function() {
   return this.find({ isActive: true }).sort({ order: 1 });
 };
 
-export default mongoose.model('TeamMember', teamMemberSchema);
+module.exports = mongoose.model('TeamMember', teamMemberSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -95,4 +95,4 @@ userSchema.methods.changedPasswordAfter = function(JWTTimestamp) {
   return false;
 };
 
-export default mongoose.model('User', userSchema);
+module.exports = mongoose.model('User', userSchema);

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -82,4 +82,4 @@ router.get('/me', protect, getMe);
 router.put('/updatedetails', protect, updateDetailsValidation, updateDetails);
 router.put('/updatepassword', protect, updatePasswordValidation, updatePassword);
 
-export default router;
+module.exports = router;

--- a/backend/routes/contactRoutes.js
+++ b/backend/routes/contactRoutes.js
@@ -75,4 +75,4 @@ router.post('/:id/notes', noteValidation, addContactNote);
 router.put('/:id/spam', markAsSpam);
 router.delete('/:id', deleteContactMessage);
 
-export default router;
+module.exports = router;

--- a/backend/routes/projectRoutes.js
+++ b/backend/routes/projectRoutes.js
@@ -106,4 +106,4 @@ router.put('/:id/order', orderValidation, updateProjectOrder);
 router.put('/:id/restore', restoreProject);
 router.get('/admin/stats', getProjectStats);
 
-export default router;
+module.exports = router;

--- a/backend/routes/teamRoutes.js
+++ b/backend/routes/teamRoutes.js
@@ -92,4 +92,4 @@ router.put('/:id/order', orderValidation, updateTeamMemberOrder);
 router.put('/:id/reactivate', reactivateTeamMember);
 router.get('/admin/stats', getTeamStats);
 
-export default router;
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -142,4 +142,4 @@ process.on('SIGTERM', () => {
   });
 });
 
-export default app;
+module.exports = app;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -12,7 +12,7 @@ import {
   TrashIcon
 } from '@heroicons/react/24/outline';
 import { teamAPI, projectsAPI, contactAPI, authAPI, handleApiError } from '../services/api';
-import { LoadingSpinner } from '../components/UI/LoadingSpinner';
+import LoadingSpinner from '../components/UI/LoadingSpinner';
 import toast from 'react-hot-toast';
 
 const Admin = () => {

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import { projectsAPI, handleApiError } from '../services/api';
-import { LoadingSpinner } from '../components/UI/LoadingSpinner';
+import LoadingSpinner from '../components/UI/LoadingSpinner';
 
 const Projects = () => {
   const { t } = useTranslation();

--- a/src/pages/Team.jsx
+++ b/src/pages/Team.jsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import { teamAPI, handleApiError } from '../services/api';
-import { LoadingSpinner } from '../components/UI/LoadingSpinner';
+import LoadingSpinner from '../components/UI/LoadingSpinner';
 
 const Team = () => {
   const { t } = useTranslation();

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+module.exports = {
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
+module.exports = defineConfig({
   plugins: [react()],
   server: {
     port: 3000,


### PR DESCRIPTION
Fix build errors by converting Node.js config and backend files to CommonJS and correcting UI component imports.

This PR resolves two main categories of build errors:
1. `SyntaxError: Unexpected token 'export'` in configuration files (e.g., `postcss.config.js`, `tailwind.config.js`, `vite.config.js`) and backend modules. This was due to using ES Module syntax (`export default`) in files expected to be CommonJS modules by Node.js. All affected files are now converted to use `module.exports`.
2. `No matching export` errors for `LoadingSpinner` in various pages. This was caused by importing `LoadingSpinner` as a named export (`{ LoadingSpinner }`) when it was defined as a default export (`export default LoadingSpinner`). The imports have been corrected to `import LoadingSpinner from ...`.